### PR TITLE
Imposing PEP8 on comparisons.

### DIFF
--- a/pznc.py
+++ b/pznc.py
@@ -74,7 +74,7 @@ class pznc(znc.Module):
 	def resolveTarget(self, target):
 		target = target.s
 		channel = self.GetNetwork().FindChan(target)
-		if channel == None:
+		if channel is None:
 			return (None, None)
 		user = self.GetNetwork().GetIRCNick()
 		return (channel, user)
@@ -123,13 +123,13 @@ class pznc(znc.Module):
 
 	def OnUserAction (self, target, message):
 		(channel, user) = self.resolveTarget(target)
-		if channel == None:
+		if channel is None:
 			return True
 		return self.OnChanAction(user, channel, message)
 
 	def OnUserMsg (self, target, message):
 		(channel, user) = self.resolveTarget(target)
-		if channel == None:
+		if channel is None:
 			return True
 		return self.OnChanMsg(user, channel, message)
 


### PR DESCRIPTION
Comparison to None should be `if cond is None` and not `if cond == None`.