### PR TITLE
Fix. crash and systemd journal flooding.

### DIFF
--- a/pznc.py
+++ b/pznc.py
@@ -81,7 +81,7 @@ class pznc(znc.Module):
 
 	def findMode(self, channel, user):
 		realUser = channel.FindNick(user.GetNick())
-		return chr(realUser.GetPermChar())
+		return realUser.GetPermChar()
 
 	def OnTopic(self, user, channel, message):
 		try:


### PR DESCRIPTION
This change fixes the "TypeError: an integer is required (got type str)" exception while logging messages from channels.
This issue was caused by an unnecessary type casting: Python3 uses Unicode by default and chr only converts integers to Unicode strings of one character, but does not support double conversions from Unicode to Unicode.

Existing users should both update and clean the DB table, because they are actually not logging the messages but only joins, parts etc.
Existing users should also clear their systemd logs.